### PR TITLE
Allow all events to be attached to the inner iFrame

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,10 @@
 import { h, Component } from 'preact';
+import partitionEventHandlers from './partition-event-handlers';
 import './style.css';
 
 const UID = Math.random().toString(32).substring(2);
 
 const EMPTY_VALUE = '<br>';
-
-/**
- * Partition an object between event handlers and non-event handlers.
- * @param {Object} props            An object with keys that may be event handlers
- * @param {Boolean} withOrWithout   If true, returns only event handlers. If false, returns only non-event handlers.
- * @returns {Object}                Returns a copy of {@param props} either with or without all event handlers (based on {@param withOrWithout}).
- */
-function partitionEventHandlers({ ...props }, withOrWithout) {
-	let key;
-	for (key in props) if (props.hasOwnProperty(key)) {
-		if (/^on/i.test(key) ^ withOrWithout === true) {
-			delete props[key];
-		}
-	}
-	return props;
-}
 
 export default class RichTextArea extends Component {
 	constructor(props) {

--- a/src/partition-event-handlers.js
+++ b/src/partition-event-handlers.js
@@ -1,0 +1,17 @@
+
+
+/**
+ * Partition an object between event handlers and non-event handlers.
+ * @param {Object} props            An object with keys that may be event handlers
+ * @param {Boolean} withOrWithout   If true, returns only event handlers. If false, returns only non-event handlers.
+ * @returns {Object}                Returns a copy of {@param props} either with or without all event handlers (based on {@param withOrWithout}).
+ */
+export default function partitionEventHandlers({ ...props }, withOrWithout) {
+	let key;
+	for (key in props) if (props.hasOwnProperty(key)) {
+		if (/^on/i.test(key) ^ withOrWithout === true) {
+			delete props[key];
+		}
+	}
+	return props;
+}

--- a/src/partition-event-handlers.js
+++ b/src/partition-event-handlers.js
@@ -6,12 +6,12 @@
  * @param {Boolean} withOrWithout   If true, returns only event handlers. If false, returns only non-event handlers.
  * @returns {Object}                Returns a copy of {@param props} either with or without all event handlers (based on {@param withOrWithout}).
  */
-export default function partitionEventHandlers({ ...props }, withOrWithout) {
-	let key;
+export default function partitionEventHandlers(props, withOrWithout) {
+	let nextProps = {}, key;
 	for (key in props) if (props.hasOwnProperty(key)) {
-		if (/^on/i.test(key) ^ withOrWithout === true) {
-			delete props[key];
+		if (/^on/i.test(key) ^ withOrWithout !== true) {
+			nextProps[key] = props[key];
 		}
 	}
-	return props;
+	return nextProps;
 }

--- a/test/partition-event-handlers.js
+++ b/test/partition-event-handlers.js
@@ -1,0 +1,24 @@
+import partitionEventHandlers from '../src/partition-event-handlers';
+import { expect } from 'chai';
+
+function noop() {}
+
+describe('partitionEventHandlers', () => {
+	const props = {
+		onFoo: noop,
+		onBar: noop,
+		title: 'Foo',
+		value: 'Bar'
+	};
+
+	it('should return only properties beginning with `on` if `withOrWithout` is true', () => {
+		const withEventHandlers = partitionEventHandlers(props, true);
+		expect(Object.keys(withEventHandlers)).to.eql([ 'onFoo', 'onBar' ]);
+	});
+
+	it('should return only properties not beginning with `on` if `withOrWithout` is false', () => {
+		const withoutEventHandlers = partitionEventHandlers(props, false);
+		expect(Object.keys(withoutEventHandlers)).to.eql([ 'title', 'value' ]);
+	});
+});
+


### PR DESCRIPTION
I would like to have the frame of the `<RichTextArea>` be able to accept any event handler, in order to do things like handle the `drop` event for enabling drag/drop.

I also want to pass the entire `event` object on when calling event handlers.

Let me know if these seem like disruptive changes, or if I am missing something about attaching handlers to the inner frame. Thanks!